### PR TITLE
Sanitize directory names to use for session names

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ This should contain a list of `:` separated absolute paths to directories
 where you keep your projects.
 Projects in this directory will be used as options
 for the `sess switch` command.
+Periods in project directory names will be replaced with underscores in the
+corresponding session names due to tmux session naming restrictions
+(tmux/tmux@9ee93b3).
 
 ### tmux bindings
 
@@ -116,7 +119,9 @@ in the current directory.
 This can be useful for creating sessions for projects
 outside of `SESS_PROJECT_ROOT`.
 
-If no session name is provided the directory name will be used
+If no session name is provided the directory name will be used, with periods
+replaced with underscores due to tmux session naming restrictions
+(tmux/tmux@9ee93b3).
 
 ### List all active sessions
 

--- a/session-sauce.plugin.zsh
+++ b/session-sauce.plugin.zsh
@@ -52,7 +52,7 @@ _sess_list_sessions() {
 
 _sess_split_name_from_dir() {
     # This is a performance bottleneck, run 8 tasks at a time.
-    xargs -P8 -I '{}' bash -c 'echo -e "{}\t$(basename {})"'
+    xargs -P8 -I '{}' bash -c 'echo -e "{}\t$(basename {} | tr . _)"'
 }
 
 _sess_pick() {
@@ -186,7 +186,7 @@ case "$1" in
     n*)
         # Create if missing, otherwise join existing
         local dir="$(pwd)"
-        local session="$(basename "$dir")"
+        local session="$(basename "$dir" | tr . _)"
         _sess_switch_session "$session" "$dir"
         ;;
 


### PR DESCRIPTION
Tmux does not accept periods in session names (tmux/tmux@9ee93b3). This
causes issue for us when directories in `$SESS_PROJECT_ROOT` have
periods in their names, and we try to use them for session names.

As a simple solution, I decided to replace all periods in the directory
basenames with underscores. My rationale here is that, often, "project
directories" are Git repositories, and underscores are used in
repository names about half as often as hyphens, according to a cursory
analysis of public GitHub repositories [available via their REST
API](https://docs.github.com/en/rest/repos/repos#list-public-repositories).

There _is_ the possibility of a name conflict due to this replacement.